### PR TITLE
keep site-container css

### DIFF
--- a/app/styles/legacy/_screen.scss
+++ b/app/styles/legacy/_screen.scss
@@ -15,6 +15,10 @@
 
 .site-container {
   padding-top: 25px;
+    // legacy styles stay loaded and override a class this is set on
+    // this limits django pages to full width on mobile
+  width: 100% !important;
+  margin: 0 !important;
 }
 
 .masthead-container {


### PR DESCRIPTION
previously this code lived in legacy/_home_compat.scss, but that file gets removed with @marineb 's homepage work.