### PR TITLE
set sort order of streams for homepage

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,7 @@
 import Route from 'ember-route';
 import service from 'ember-service/inject';
 import PlayParamMixin from 'wqxr-web-client/mixins/play-param';
+import DS from 'ember-data';
 
 const carouselBg = 'https://images.unsplash.com/photo-1481462585914-9f695507135e?dpr=2&auto=format&fit=crop&w=1500&h=1500&q=80&cs=tinysrgb';
 
@@ -18,8 +19,14 @@ export default Route.extend(PlayParamMixin, {
   },
   setupController(controller) {
     this._super(...arguments);
-    controller.set('audio', this.get('audio'));
-    controller.set('streams', this.store.findAll('stream', {reload: true}));
+    
+    let streams = DS.PromiseArray.create({
+      promise: this.store.findAll('stream', {reload: true}).then(s => {
+        return s.filterBy('liveWQXR').concat(s.filterBy('isWNYC'));
+      })
+    });
+    controller.set('streams', streams);
     controller.set('carouselBg', carouselBg);
+    controller.set('audio', this.get('audio'));
   }
 });


### PR DESCRIPTION
using a `DS.PromiseArray` so the `stream-banner` component can have access to the nice `isFulfilled`, `isPending`, etc attrs

[ticket](https://jira.wnyc.org/browse/WE-6881)