### PR TITLE
refactor homepage streams with conditional logic for data display

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "nypr-account-settings": "nypublicradio/nypr-account-settings",
     "nypr-ads": "nypublicradio/nypr-ads",
     "nypr-player": "nypublicradio/nypr-player",
-    "nypr-stream-carousel": "nypublicradio/nypr-stream-carousel#higher-order-refactor",
+    "nypr-stream-carousel": "nypublicradio/nypr-stream-carousel",
     "nypr-ui": "nypublicradio/nypr-ui",
     "torii": "0.8.1"
   },


### PR DESCRIPTION
depends upon nypublicradio/nypr-stream-carousel#2

for [WE-7213](https://jira.wnyc.org/browse/WE-7213) and [WE-7219](https://jira.wnyc.org/browse/WE-7213)

moves display logic out of addon and into app templates. adds some logic to determine whether or not to show certain pieces of metadata.