### PR TITLE
don't show scrollbars on schedule tabs

### DIFF
--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -46,6 +46,10 @@
     li:last-child a {
       margin: 0;
     }
+    /* hide the scrollbar, but keep it scrollable */
+    &::-webkit-scrollbar { 
+      display: none; 
+    }
   }
   ul.schedule-tabs li.ui-tabs-selected a {
     color: $wqxrlink;


### PR DESCRIPTION
This fixes a bug on PC/Chrome