### PR TITLE
Add xml report output in circle ci to test config

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,18 @@
 /*jshint node:true*/
+function reportFile() {
+  if (_circleTestFolder()) {
+    return _circleTestFolder() + '/test.xml';
+  }
+}
+
+function testReporter() {
+  return _circleTestFolder() ? 'xunit' : 'tap';
+}
+
+function _circleTestFolder() {
+  return process.env['CIRCLE_TEST_REPORTS'];
+}
+
 module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
@@ -9,5 +23,8 @@ module.exports = {
   "launch_in_dev": [
     "Chrome",
     "Firefox"
-  ]
+  ],
+  "reporter": testReporter(),
+  "report_file": reportFile(),
+  "xunit_intermediate_output": true
 };


### PR DESCRIPTION
Enables this tab in the Circle CI build page:

![screen shot 2017-06-26 at 11 18 24 am](https://user-images.githubusercontent.com/6074785/27546608-439985f8-5a61-11e7-823b-517ef06da4b9.png)
https://circleci.com/gh/nypublicradio/wqxr-web-client/1444

Also adds an .xml test report with individual test timings to the circle artifacts folders.

Local testing should remain unaffected by this change.
