### PR TITLE
Update channel redirects

### DIFF
--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -37,11 +37,10 @@ export default Route.extend(PlayParamMixin, {
 
   afterModel({ channel }, transition) {
     if (channel) {
-      let canonicalUrl = get(channel, 'url');
-      let canonicalHostMatch = canonicalUrl && canonicalUrl.match(/\/\/([\w.]+)\//);
-      if  (canonicalHostMatch && canonicalHostMatch.pop() !== document.location.host) {
+      let canonicalHost = get(channel, 'canonicalHost');
+      if  (canonicalHost && canonicalHost !== document.location.host) {
         transition.abort();
-        window.location.href = canonicalUrl;
+        window.location.href = get(channel, 'url');
         return;
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,6 +3442,12 @@ ember-invoke-action@^1.4.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
+ember-keyboard@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.1.9.tgz#52a810b749d23ca5bafd4484fd101bf0b73811ab"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
@@ -6570,8 +6576,8 @@ nypr-player@nypublicradio/nypr-player:
     nypr-ui nypublicradio/nypr-ui#demo
 
 nypr-publisher-lib@~0.0.0:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.0.4.tgz#695664e4d70d747229d8e8532f1cc778f4122e56"
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.0.5.tgz#459d6ab0d605e8d3bcedb0027165e778b78bc6b6"
   dependencies:
     ember-cli-babel "^6.3.0"
     ember-cli-htmlbars "^2.0.1"
@@ -6602,6 +6608,21 @@ nypr-publisher-lib@~0.0.0:
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
   resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/ced4941be41845a96c926c2ca8668cc64fa58209"
+  dependencies:
+    ember-basic-dropdown "0.33.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-cli-htmlbars-inline-precompile "^0.4.3"
+    ember-cli-sass "^7.0.0"
+    ember-click-outside "0.1.9"
+    ember-composable-helpers "2.0.1"
+    ember-holygrail-layout "^0.1.4"
+    ember-power-select "^1.9.2"
+    ivy-tabs "3.1.0"
+
+nypr-ui@nypublicradio/nypr-ui#demo:
+  version "0.0.0"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/c504af1debd1670df12869fcf34eb6103b1f48fe"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
Now using canonicalHost from the channel model in nypr-publisher-lib v0.0.5