### PR TITLE
Fix firefox quantum player bug by forcing the player into the correct mode

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -37,6 +37,7 @@
       backdropImageUrl = integration.backdropImageUrl
       storyTitle       = integration.storyTitle
       showTitle        = integration.showTitle
+      isAudiostream    = integration.isStream
       as |content|}}
         {{#content.for 'trackInfo'}}
           {{nypr-player-integration/track-info


### PR DESCRIPTION
Fix firefox quantum player bug by forcing the player into the correct mode and not relying on hifi to detect streaming audio.