### PR TITLE
channel route migration

### DIFF
--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -8,7 +8,7 @@ const {
 } = Ember;
 const { hash: waitFor } = Ember.RSVP;
 const inflector = new Inflector(Inflector.defaultRules);
-import { retryFromServer, beforeTeardown } from 'nypr-django-for-ember/utils/compat-hooks';
+import { beforeTeardown } from 'nypr-django-for-ember/utils/compat-hooks';
 import PlayParamMixin from 'wqxr-web-client/mixins/play-param';
 import config from 'wqxr-web-client/config/environment';
 
@@ -21,18 +21,15 @@ export default Route.extend(PlayParamMixin, {
     const listingSlug = `${channelPathName}/${params.slug}`;
     set(this, 'listingSlug', listingSlug);
 
+    let channel = this.store.findRecord('channel', listingSlug);
     let listenLive = this.store.findRecord('chunk', `shows-${params.slug}-listenlive`)
       .catch(() => '');
 
-    return this.store.find('django-page', listingSlug.replace(/\/*$/, '/')).then(page => {
-      return waitFor({
-        page,
-        channel: page.get('wnycChannel'),
-        user: this.get('session.data.authenticated'),
-        listenLive
-      });
-    })
-    .catch(e => retryFromServer(e, listingSlug.replace(/\/*$/, '/')));
+    return waitFor({
+      channel,
+      listenLive,
+      user: this.get('session.data.authenticated'),
+    });
   },
 
   afterModel({ channel }, transition) {

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -1,106 +1,104 @@
-{{#django-page page=model.page}}
-  {{#if model.channel.altLayout}}
-    {{#alt-channel-layout
-      defaultSlug=defaultSlug
-      channelType=channelType
-      channel=model.channel
-      adminURL=adminURL
-      isStaff=session.data.isStaff
-      item=model.channel.featured}}
+{{#if model.channel.altLayout}}
+  {{#alt-channel-layout
+    defaultSlug=defaultSlug
+    channelType=channelType
+    channel=model.channel
+    adminURL=adminURL
+    isStaff=session.data.isStaff
+    item=model.channel.featured}}
 
-      {{outlet}}
+    {{outlet}}
 
-      {{page-numbers
-        currentPage=pageNumbers.page
-        totalPages=pageNumbers.totalPages
-        action="pageNumberClicked"}}
+    {{page-numbers
+      currentPage=pageNumbers.page
+      totalPages=pageNumbers.totalPages
+      action="pageNumberClicked"}}
 
-    {{/alt-channel-layout}}
+  {{/alt-channel-layout}}
+{{else}}
+  {{#if model.channel.hasMarquee}}
+    {{x-marquee listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
   {{else}}
-    {{#if model.channel.hasMarquee}}
-      {{x-marquee listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
-    {{else}}
-      {{channel-header listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
+    {{channel-header listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
+  {{/if}}
+
+<div class="l-constrained">
+  <main class="l-col2of3">
+
+    {{#if model.channel.featured}}
+    <section>
+      <h1 class="for-screenreaders">Featured Item</h1>
+      {{story-tease
+        parentTitle=model.channel.title
+        isStaff=session.data.isStaff
+        adminURL=adminURL
+        allowQueueing=false
+        item=model.channel.featured
+        hideLinks=true
+        isFeatured=true
+        class='box box--bgoverflow'
+        playContext='FeaturedItem'}}
+    </section>
     {{/if}}
 
-  <div class="l-constrained">
-    <main class="l-col2of3">
+    {{#if model.channel.linkroll}}
+      {{nav-links
+        defaultSlug=defaultSlug
+        navRoot=channelType
+        links=model.channel.linkroll}}
+    {{/if}}
 
-      {{#if model.channel.featured}}
-      <section>
-        <h1 class="for-screenreaders">Featured Item</h1>
-        {{story-tease
-          parentTitle=model.channel.title
-          isStaff=session.data.isStaff
-          adminURL=adminURL
-          allowQueueing=false
-          item=model.channel.featured
-          hideLinks=true
-          isFeatured=true
-          class='box box--bgoverflow'
-          playContext='FeaturedItem'}}
-      </section>
-      {{/if}}
+    {{outlet}}
 
-      {{#if model.channel.linkroll}}
-        {{nav-links
-          defaultSlug=defaultSlug
-          navRoot=channelType
-          links=model.channel.linkroll}}
-      {{/if}}
+    {{page-numbers
+      currentPage=pageNumbers.page
+      totalPages=pageNumbers.totalPages
+      action="pageNumberClicked"}}
 
-      {{outlet}}
+  </main>
 
-      {{page-numbers
-        currentPage=pageNumbers.page
-        totalPages=pageNumbers.totalPages
-        action="pageNumberClicked"}}
+  <aside class="l-col1of3">
+    <div class="l-skinny">
 
-    </main>
-
-    <aside class="l-col1of3">
-      <div class="l-skinny">
-
-        {{#if model.channel.tease}}
-        <div class="box box--nopad">
-          <div class="box-heading">
-            <h1 class="h5">About the {{capitalize-word model.channel.listingObjectType}}</h1>
-          </div>
-          <div class="text text--medium">
-            <div class="text-body text-body--nopad text-body--forceinline">
-              {{django-page page=model.channel.teaseForDjangoPage loadingType='channel-page'}}
-              {{#if model.channel.producingOrganizations}}
-                Produced by {{producing-orgs model.channel.producingOrganizations}}.
-              {{/if}}
-            </div>
+      {{#if model.channel.tease}}
+      <div class="box box--nopad">
+        <div class="box-heading">
+          <h1 class="h5">About the {{capitalize-word model.channel.listingObjectType}}</h1>
+        </div>
+        <div class="text text--medium">
+          <div class="text-body text-body--nopad text-body--forceinline">
+            {{django-page page=model.channel.teaseForDjangoPage loadingType='channel-page'}}
+            {{#if model.channel.producingOrganizations}}
+              Produced by {{producing-orgs model.channel.producingOrganizations}}.
+            {{/if}}
           </div>
         </div>
-        <!-- .box -->
-        {{/if}}
-
-
-        {{social-links
-          facebook=model.channel.facebook.firstObject
-          twitter=model.channel.twitter.firstObject
-          newsletter=model.channel.newsletter.firstObject}}
-
-        {{#if model.channel.chunkSidebarTop}}
-          {{django-page page=model.channel.chunkSidebarTop loadingType='channel-page' class='channel-sidebar-chunk'}}
-        {{/if}}
-
-        {{dfp-ad
-          slotClassNames="align--mq-centertoright channel-ad"
-          slot="/6483581/rectangle/wqxr_rectangle"
-          target="rightRail"
-          sizes=(array (array 300 250) (array 300 600))}}
-
-        {{#if model.channel.chunkSidebarBottom}}
-          {{django-page page=model.channel.chunkSidebarBottom loadingType='channel-page'}}
-        {{/if}}
-
       </div>
-      <!-- .l-skinny -->
-    </aside>
-  </div>
-  {{/if}}
-{{/django-page}}
+      <!-- .box -->
+      {{/if}}
+
+
+      {{social-links
+        facebook=model.channel.facebook.firstObject
+        twitter=model.channel.twitter.firstObject
+        newsletter=model.channel.newsletter.firstObject}}
+
+      {{#if model.channel.chunkSidebarTop}}
+        {{django-page page=model.channel.chunkSidebarTop loadingType='channel-page' class='channel-sidebar-chunk'}}
+      {{/if}}
+
+      {{dfp-ad
+        slotClassNames="align--mq-centertoright channel-ad"
+        slot="/6483581/rectangle/wqxr_rectangle"
+        target="rightRail"
+        sizes=(array (array 300 250) (array 300 600))}}
+
+      {{#if model.channel.chunkSidebarBottom}}
+        {{django-page page=model.channel.chunkSidebarBottom loadingType='channel-page'}}
+      {{/if}}
+
+    </div>
+    <!-- .l-skinny -->
+  </aside>
+</div>
+{{/if}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -26,48 +26,48 @@ const hasProvider = function(request) {
 
 export default function() {
   this.logging = false;
-  let baseUrl = config.webRoot;
 
   /*------------------------------------------------------------
     legacy (v1) endpoints
   --------------------------------------------------------------*/
 
-  this.get(`${baseUrl}/api/v1/story/:id`);
-  this.get(`${baseUrl}/api/v1/browser_id/`, {success: true});
-  this.get(`${baseUrl}/api/v1/list/comments/24/:storyId/`, 'comment');
-  this.get(`${config.publisherAPI}/v1/whats_on/`);
-  this.get(`${baseUrl}/api/v1/whats_on/:slug`, 'whats-on');
-  this.get('/api/v1/whats_on/:slug', 'whats-on');
-  this.get(`${baseUrl}/api/v1/list/streams/`);
-  this.get('/api/v1/list/streams/');
-  this.get(`${baseUrl}/api/v1/list/streams/:slug`, 'stream');
-  this.get('/api/v1/list/streams/:slug', 'stream');
+  this.urlPrefix = config.publisherAPI;
 
-  this.post(`${config.publisherAPI}/v1/listenaction/create/:id/play/`, {});
-  this.post(`${config.publisherAPI}/v1/listenaction/create/:id/complete/`, {});
-  this.post(`${config.publisherAPI}/most/view/managed_item/:id/`, {});
-  this.post(`${config.publisherAPI}/most/listen/managed_item/:id/`, {});
+  this.get('/v1/story/:id');
+  this.get('/v1/list/comments/24/:storyId/', 'comment');
+  this.get('/v1/whats_on/');
+  this.get('/v1/whats_on/:slug', 'whats-on');
+  this.get('/v1/list/streams/');
+  this.get('/v1/list/streams/:slug', 'stream');
+
+  this.post('/v1/listenaction/create/:id/play/', {});
+  this.post('/v1/listenaction/create/:id/complete/', {});
+  this.post('/most/view/managed_item/:id/', {});
+  this.post('/most/listen/managed_item/:id/', {});
+
+  this.get('/v1/browser_id/', {success: true});
 
   /*------------------------------------------------------------
     transitional (v2) endpoints
   --------------------------------------------------------------*/
 
-  this.get(`${baseUrl}/api/v2/related/:storyId/`, 'story');
+  this.get('/v2/related/:storyId/', 'story');
 
   /*------------------------------------------------------------
     JSON:API (v3) endpoints
   --------------------------------------------------------------*/
 
-  this.get(`/api/v3/shows`);
-  this.get(`${baseUrl}/api/v3/shows`);
-  this.get(`${baseUrl}/api/v3/buckets/:slug/`, 'bucket');
-  this.get(`${baseUrl}/api/v3/story-pk/:id/`, 'story');
-  this.get(`${baseUrl}/api/v3/story/:slug/`, ({ stories }, { params }) => {
+  this.get('/v3/shows');
+  this.get('/v3/buckets/:slug/',  ({ buckets }, { params }) => {
+    return buckets.findBy({ slug: params.slug });
+  });
+  this.get('/v3/story-pk/:id/', 'story');
+  this.get('/v3/story/:slug/', ({ stories }, { params }) => {
     let { slug } = params;
     return stories.where({ slug }).models[0];
   });
-  this.get(`${baseUrl}/api/v3/story/related/`, 'story');
-  this.get(`${baseUrl}/v3/channel/*id`, ({ apiResponses, listingPages }, { params }) => {
+  this.get('/v3/story/related/', 'story');
+  this.get('/v3/channel/*id', ({ apiResponses, listingPages }, { params }) => {
     let { id } = params;
     if (id.split('/').length === 2) {
       // listing-page
@@ -77,16 +77,17 @@ export default function() {
       return apiResponses.find(id);
     }
   });
-  this.get(`${baseUrl}/api/v3/chunks/:id/`, 'chunk');
+  this.get('/v3/chunks/:id/', 'chunk');
 
   /*------------------------------------------------------------
     identity management (account) endpoints
   --------------------------------------------------------------*/
-  this.get(`${config.adminRoot}/api/v1/is_logged_in/`, {});
-  this.get(`${config.adminRoot}/comments/security_info/`, {security_hash: 'foo', timestamp: Date.now()});
+  this.urlPrefix = config.adminRoot;
 
-  this.post(`${config.adminRoot}/api/v1/accounts/logout/`, {successful_logout: true});
-  this.post(`${config.adminRoot}/api/v1/accounts/login/`, function(schema, request) {
+  this.get('/comments/security_info/', {security_hash: 'foo', timestamp: Date.now()});
+  this.get('/api/v1/is_logged_in/', {});
+  this.post('/api/v1/accounts/logout/', {successful_logout: true});
+  this.post('/api/v1/accounts/login/', function(schema, request) {
     let params = {};
     request.requestBody.split('&').forEach(p => {
       params[p.split('=')[0]] = p.split('=')[1];
@@ -106,22 +107,24 @@ export default function() {
     passthroughs
   --------------------------------------------------------------*/
 
+  this.urlPrefix = ''
+
   // Let this one slip by, we've got a http-proxy for it
-  this.passthrough(`/api/v1/dynamic-script-loader`);
-  this.passthrough(`${baseUrl}/api/v1/dynamic-script-loader`);
-  this.passthrough(`${baseUrl}/api/v1/schedule/whats_on_today/*`);
+  this.passthrough('/api/v1/dynamic-script-loader');
+  this.passthrough(`${config.publisherAPI}/api/v1/dynamic-script-loader`);
+  this.passthrough(`${config.publisherAPI}/api/v1/schedule/whats_on_today/*`);
   this.passthrough('/datanewswidget/**');
 
   /*------------------------------------------------------------
   ${webRoot}/* requests. Oddballs without the api namespace
   --------------------------------------------------------------*/
 
-  this.get(`${baseUrl}`, function(schema) {
+  this.get(`${config.webRoot}`, function(schema) {
     let home = schema.djangoPages.find('/');
     return home ? home.attrs.text : '';
   });
 
-  this.get(`${baseUrl}/*id`, function(schema, {queryParams, params}) {
+  this.get(`${config.webRoot}/*id`, function(schema, {queryParams, params}) {
     let { id } = params;
     let page = schema.djangoPages.find(id);
     if (!page) {
@@ -132,6 +135,7 @@ export default function() {
     }
     return page || new Response(404);
   });
+
 
   /*-------------------------------------------------------------
   auth microservice
@@ -249,15 +253,19 @@ export default function() {
   analytics microservice
   ---------------------------------------------------------------*/
 
-  this.post(`${config.platformEventsAPI}/v1/events/viewed`, {});
-  this.post(`${config.platformEventsAPI}/v1/events/listened`, {});
+  this.urlPrefix = config.platformEventsAPI;
+
+  this.post('/v1/events/viewed', {});
+  this.post('/v1/events/listened', {});
 
   /*-------------------------------------------------------------
   membership microservice
   ---------------------------------------------------------------*/
-  this.get(`${config.membershipAPI}/v1/orders/`, 'orders');
-  this.get(`${config.membershipAPI}/v1/emails/is-verified/`, {data: {is_verified: true}});
-  this.patch(`${config.membershipAPI}/v1/emails/:email_id/verify/`, (schema, request) => {
+  this.urlPrefix = config.membershipAPI;
+
+  this.get('/v1/orders/', 'orders');
+  this.get('/v1/emails/is-verified/', {data: {is_verified: true}});
+  this.patch('/v1/emails/:email_id/verify/', (schema, request) => {
     let params = JSON.parse(request.requestBody);
     if (params &&
         get(params, 'data.attributes.verification_token') &&

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -67,7 +67,16 @@ export default function() {
     return stories.where({ slug }).models[0];
   });
   this.get(`${baseUrl}/api/v3/story/related/`, 'story');
-  this.get(`${baseUrl}/api/v3/channel/*id`, 'api-response');
+  this.get(`${baseUrl}/v3/channel/*id`, ({ apiResponses, listingPages }, { params }) => {
+    let { id } = params;
+    if (id.split('/').length === 2) {
+      // listing-page
+      return listingPages.find(id);
+    } else {
+      // api response object
+      return apiResponses.find(id);
+    }
+  });
   this.get(`${baseUrl}/api/v3/chunks/:id/`, 'chunk');
 
   /*------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "nypr-django-for-ember": "~0.0.0",
     "nypr-metrics": "~0.0.0",
     "nypr-player": "~0.0.0",
-    "nypr-publisher-lib": "^0.2.15",
+    "nypr-publisher-lib": ">=0.3.0",
     "nypr-ui": "~0.1.7",
     "torii": "0.9.5"
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     ]
   },
   "resolutions": {
-    "nypr-metrics": "<0.1.0"
+    "nypr-metrics": "<0.1.0",
+    "nypr-audio-services": "0.2.7"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/acceptance/listing-page-test.js
+++ b/tests/acceptance/listing-page-test.js
@@ -1,6 +1,5 @@
 import test from 'ember-sinon-qunit/test-support/test';
 import moduleForAcceptance from 'wqxr-web-client/tests/helpers/module-for-acceptance';
-import djangoPage from 'wqxr-web-client/tests/pages/django-page';
 import showPage from 'wqxr-web-client/tests/pages/show';
 import config from 'wqxr-web-client/config/environment';
 import moment from 'moment';
@@ -13,22 +12,19 @@ moduleForAcceptance('Acceptance | Listing Page | viewing', {
 });
 
 test('smoke test', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'}
     ],
     socialLinks: [{title: 'facebook', href: 'http://facebook.com'}],
     apiResponse: server.create('api-response', { id: 'shows/foo/episodes/1' })
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), `${listingPage.id}`);
+    assert.equal(currentURL(), 'shows/foo');
     assert.ok(findWithAssert('.sitechrome-btn'), 'donate chunk should reset after navigating');
     assert.ok(showPage.facebookIsVisible());
     assert.notOk(find('[data-test-selector="admin-link"]').length, 'edit link should not be visible');
@@ -38,19 +34,16 @@ test('smoke test', function(assert) {
 test('authenticated smoke test', function(assert) {
   server.get(`${config.adminRoot}/api/v1/is_logged_in/`, {is_staff: true});
   server.create('user');
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'}
     ],
     socialLinks: [{title: 'facebook', href: 'http://facebook.com'}],
     apiResponse: server.create('api-response', { id: 'shows/foo/episodes/1' })
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(() => {
     andThen(() => assert.ok(find('[data-test-selector="admin-link"]').length, 'edit links are visible'));
@@ -58,18 +51,15 @@ test('authenticated smoke test', function(assert) {
 });
 
 test('about smoke test', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'about', title: 'About'},
     ],
     apiResponse: server.create('api-response', { id: 'shows/foo/about' })
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     assert.equal(showPage.aboutText(), 'About');
@@ -83,18 +73,15 @@ test('visiting a listing page - story page smoke test', function(assert) {
     story: server.create('story')
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'story', title: 'Story'}
     ],
     apiResponse
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(() => {
     assert.equal(showPage.storyText(), 'Story body.');
@@ -123,18 +110,15 @@ test('scripts in well route content will execute', function(assert) {
     story
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'story', title: 'Story'}
     ],
     apiResponse
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     assert.equal(find('[data-test-selector=story-detail] p').length, 1, 'should only be one p tag');
@@ -153,8 +137,8 @@ test('using a nav-link', function(assert) {
     teaseList: server.createList('story', 1, {title: 'Story Title'})
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
       {'nav-slug': 'next-link', title: 'Next Link'}
@@ -162,11 +146,7 @@ test('using a nav-link', function(assert) {
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   showPage.clickNavLink('Next Link');
 
@@ -185,8 +165,8 @@ test('visiting directly to a nav link url', function(assert) {
     teaseList: server.createList('story', 1, {title: 'Story Title'})
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
       {'nav-slug': 'next-link', title: 'Next Link'}
@@ -194,11 +174,7 @@ test('visiting directly to a nav link url', function(assert) {
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
-  djangoPage
-    .bootstrap(listingPage)
-    .visit({id: 'shows/foo/next-link/'});
+  visit('shows/foo/next-link/');
 
   andThen(() => {
     assert.equal(currentURL(), `shows/foo/next-link/`);
@@ -212,19 +188,16 @@ test('null social links should not break page', function(assert) {
     id: 'shows/foo/recent_stories/1',
     teaseList: server.createList('story', 10)
   });
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     socialLinks: null,
     apiResponse
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), `${listingPage.id}`);
+    assert.equal(currentURL(), 'shows/foo');
   });
 });
 
@@ -233,35 +206,29 @@ test('undefined social links should not break page', function(assert) {
     id: 'shows/foo/recent_stories/1',
     teaseList: server.createList('story', 10)
   });
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     socialLinks: undefined,
     apiResponse
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), `${listingPage.id}`);
+    assert.equal(currentURL(), 'shows/foo');
   });
 });
 
 test('visiting a show with a different header donate chunk', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     headerDonateChunk: '<a href="http://foo.com" class="foo">donate to foo</a>',
     apiResponse: server.create('api-response', { id: 'shows/foo/recent_stories/1' })
   });
-  server.create('django-page', {id: listingPage.id});
-  server.create('django-page', {id: 'fake/'});
+  server.create('django-page', {id: '/'});
   server.create('bucket', {slug: 'wqxr-home'}); // redirected to homepage
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo')
 
   andThen(function() {
     assert.equal(find('.foo').text(), 'donate to foo', 'donate chunk should match');
@@ -278,18 +245,15 @@ test('visiting a show with a different header donate chunk', function(assert) {
 
 test('show pages with a play param', function(assert) {
   let story = server.create('story');
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     apiResponse: server.create('api-response', { id: 'shows/foo/recent_stories/1' })
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit({id: listingPage.id + `?play=${story.slug}`});
+  visit(`shows/foo?play=${story.slug}`);
 
   andThen(function() {
-    assert.equal(currentURL(), `${listingPage.id}?play=${story.slug}`);
+    assert.equal(currentURL(), `shows/foo?play=${story.slug}`);
     assert.ok(find('.nypr-player').length, 'persistent player should be visible');
     assert.equal(find('[data-test-selector=nypr-player-story-title]').text(), story.title, `${story.title} should be loaded in player UI`);
   });
@@ -297,8 +261,8 @@ test('show pages with a play param', function(assert) {
 });
 
 test('show pages with a listen live chunk', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/'
+  server.create('listing-page', {
+    id: 'shows/foo'
   });
   server.create('api-response', { id: 'shows/foo/recent_stories/1' });
 
@@ -306,23 +270,20 @@ test('show pages with a listen live chunk', function(assert) {
     id: 'shows-foo-listenlive',
     content: 'foo bar text'
   });
-  server.create('django-page', {id: listingPage.id});
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
-  
+
+  visit('shows/foo');
+
   andThen(() => {
     assert.equal(find('.channel-header .django-content').text().trim(), 'foo bar text');
   });
 });
 
 test('channel routes do dfp targeting', function(/*assert*/) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/'
+  server.create('listing-page', {
+    id: 'shows/foo'
   });
   server.create('api-response', { id: 'shows/foo/recent_stories/1' });
-  server.create('django-page', {id: listingPage.id});
-  
+
   // https://github.com/emberjs/ember.js/issues/14716#issuecomment-267976803
   visit('/');
 
@@ -331,10 +292,8 @@ test('channel routes do dfp targeting', function(/*assert*/) {
       .expects('doTargeting')
       .once();
   });
-  
-  djangoPage
-    .bootstrap({id: listingPage.id})
-    .visit({id: listingPage.id});
+
+  visit('shows/foo');
 });
 
 test('if a show is airing, the featured story listen button says "Listen Live"', function(assert) {
@@ -346,8 +305,8 @@ test('if a show is airing, the featured story listen button says "Listen Live"',
   });
   let featured = {};
   Object.keys(featuredStory.attrs).forEach(k => featured[k.dasherize()] = featuredStory.attrs[k]);
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     featured,
     apiResponse: server.create('api-response', { id: 'shows/foo/recent_stories/1' })
   });
@@ -359,11 +318,8 @@ test('if a show is airing, the featured story listen button says "Listen Live"',
       }
     }
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(() => {
     let button = find('[data-test-selector=listen-button]');
@@ -379,8 +335,8 @@ test('if a show is airing, the featured story listen button says "Listen Live"',
 moduleForAcceptance('Acceptance | Listing Page | Analytics');
 
 test('metrics properly reports channel attrs', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     cmsPK: 123,
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'}
@@ -391,8 +347,6 @@ test('metrics properly reports channel attrs', function(assert) {
 
   assert.expect(2);
 
-  server.create('django-page', {id: listingPage.id});
-  
   server.post(`${config.platformEventsAPI}/v1/events/viewed`, (schema, {requestBody}) => {
     let {
       cms_id,
@@ -423,15 +377,13 @@ test('metrics properly reports channel attrs', function(assert) {
     }
   };
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 });
 
 test('listen buttons in story teases include data-story and data-show values', function(assert) {
   let teaseList = server.createList('story', 5, {audioAvailable: true, showTitle: 'foo show'});
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     cmsPK: 123,
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'}
@@ -441,12 +393,8 @@ test('listen buttons in story teases include data-story and data-show values', f
       teaseList
     })
   });
-  server.create('django-page', {id: listingPage.id});
 
-
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(() => {
     let listenButtons = findWithAssert('.story-tease [data-test-selector=listen-button]');

--- a/tests/acceptance/paginating-listing-page-test.js
+++ b/tests/acceptance/paginating-listing-page-test.js
@@ -1,6 +1,5 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'wqxr-web-client/tests/helpers/module-for-acceptance';
-import djangoPage from 'wqxr-web-client/tests/pages/django-page';
 import showPage from 'wqxr-web-client/tests/pages/show';
 
 moduleForAcceptance('Acceptance | Listing Page | paginating');
@@ -12,19 +11,15 @@ test('showing pagination for a list of episodes', function(assert) {
     totalCount: 50
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'}
     ],
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     assert.equal(find('#pagefooter').length, 1, 'is showing pagination');
@@ -32,18 +27,15 @@ test('showing pagination for a list of episodes', function(assert) {
 });
 
 test('showing no pagination on about pages', function(assert) {
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'about', title: 'About'},
     ],
     apiResponse: server.create('api-response', { id: 'shows/foo/about' })
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     assert.equal(find('#pagefooter').length, 0, 'is not showing pagination');
@@ -56,18 +48,15 @@ test('showing no pagination on story detail listing pages', function(assert) {
     story: server.create('story')
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'story', title: 'Story'}
     ],
     apiResponse
   });
-  server.create('django-page', {id: listingPage.id});
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     assert.equal(find('#pagefooter').length, 0, 'is not showing pagination');
@@ -89,20 +78,17 @@ test('can go back and forward', function(assert) {
     totalCount: 50
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
     ],
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
   let firstStoryTitle;
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     firstStoryTitle = showPage.storyTitles()[0];
@@ -136,19 +122,15 @@ test('proper paginating for listing pages without a linkroll', function(assert) 
     totalCount: 50
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), 'shows/foo/');
+    assert.equal(currentURL(), 'shows/foo');
     showPage.clickNext();
   });
   andThen(function() {
@@ -174,21 +156,17 @@ test('can navigate to a specified page of results', function(assert) {
     teaseList: server.createList('story', 10)
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
     ],
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
   let firstStoryTitle;
 
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
+  visit('shows/foo');
 
   andThen(function() {
     firstStoryTitle = showPage.storyTitles()[0];
@@ -214,23 +192,18 @@ test('can land on a page number', function(assert) {
     teaseList: server.createList('story', 50)
   });
 
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
     ],
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-
-  djangoPage
-    .bootstrap(listingPage);
-  
-  visit(`/${api5}`);
+  visit(api5);
 
   andThen(function() {
-    assert.equal(currentURL(), `/${api5}`, 'can land directly on a page of results');
+    assert.equal(currentURL(), api5, 'can land directly on a page of results');
     assert.equal(find('.pagefooter-current').text().trim(), '5', 'current page number is 5');
   });
 });
@@ -241,19 +214,15 @@ test('it only shows ten pages at a time', function(assert) {
     teaseList: server.createList('story', 10),
     totalCount: 500
   });
-  
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [{'nav-slug': 'episodes', title: 'Episodes'}],
     apiResponse
   });
-  
-  server.create('django-page', {id: listingPage.id});
-  
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
-  
+
+  visit('shows/foo');
+
   andThen(function() {
     assert.equal(find('.pagefooter-current').length, 1, 'one current page number');
     assert.equal(find('.pagefooter-link').length, 10, 'links 2-9 and one final page');
@@ -272,7 +241,7 @@ test('clicking on a page number takes to the page of the correct tab', function(
   });
   let segmentsPage1 = 'shows/foo/segments/1';
   let segmentsPage3 = 'shows/foo/segments/3';
-  
+
   server.create('api-response', {
     id: segmentsPage1,
     teaseList: server.createList('story', 10),
@@ -283,9 +252,9 @@ test('clicking on a page number takes to the page of the correct tab', function(
     teaseList: server.createList('story', 10),
     totalCount: 60
   });
-  
-  let listingPage = server.create('listing-page', {
-    id: 'shows/foo/',
+
+  server.create('listing-page', {
+    id: 'shows/foo',
     linkroll: [
       {'nav-slug': 'episodes', title: 'Episodes'},
       {'nav-slug': 'segments', title: 'Segments'}
@@ -293,12 +262,8 @@ test('clicking on a page number takes to the page of the correct tab', function(
     apiResponse
   });
 
-  server.create('django-page', {id: listingPage.id});
-  
-  djangoPage
-    .bootstrap(listingPage)
-    .visit(listingPage);
-  
+  visit('shows/foo');
+
   andThen(() => {
     showPage.clickNavLink('Segments');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,13 +2132,17 @@ colors@1.0.3, colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@^1.1.2, colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+colors@^1.1.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
 
 colors@~0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
+
+colors@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -2780,7 +2784,7 @@ ember-cli-autoprefixer@^0.6.0:
     broccoli-autoprefixer "^4.1.0"
     lodash "^4.0.0"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5:
+ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2790,7 +2794,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz#0356b03cc3fdff5d0f2ecaa46a0e1cfaebffd876"
   dependencies:
@@ -2800,7 +2804,7 @@ ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
   dependencies:
@@ -3665,12 +3669,6 @@ ember-invoke-action@^1.4.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-lifeline@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-1.3.0.tgz#33baf11287ea425103cd6c3299b9d9d15d1e4c54"
-  dependencies:
-    ember-cli-babel "^5.1.7"
-
 ember-lifeline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-2.0.0.tgz#ab2dadd3eed585605d1c4137c64aacec4d241c8e"
@@ -3907,19 +3905,6 @@ ember-simple-auth@^1.4.0:
     ember-getowner-polyfill "^1.1.0 || ^2.0.0"
     silent-error "^1.0.0"
 
-ember-singularity-mixins@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/ember-singularity-mixins/-/ember-singularity-mixins-1.3.3.tgz#c3b12679b2725101617fe1a2b61986a2af787fb4"
-  dependencies:
-    ember-cli-babel "^5.1.5"
-    ember-singularity "^1.0.4"
-
-ember-singularity@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-singularity/-/ember-singularity-1.2.0.tgz#d63fdca74ba6ef1c3ab9932e2ddead2bb36973c4"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-sinon-qunit@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-sinon-qunit/-/ember-sinon-qunit-2.1.0.tgz#85fd64e73db40148816a46a64f9f78b170b72cb2"
@@ -3976,17 +3961,6 @@ ember-text-measurer@^0.4.0:
   resolved "https://registry.yarnpkg.com/ember-text-measurer/-/ember-text-measurer-0.4.0.tgz#a676195378d4eb4c1617678c2d198a2344b4d12b"
   dependencies:
     ember-cli-babel "^6.8.2"
-
-ember-truncate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-truncate/-/ember-truncate-1.0.0.tgz#4fe007be85b92d3e4903c6ea5b5b9be9460afd4b"
-  dependencies:
-    ember-cli-babel "^6.7.1"
-    ember-cli-htmlbars "^2.0.1"
-    ember-diff-attrs "^0.1.2"
-    ember-lifeline "^1.3.0"
-    ember-singularity-mixins "^1.3.3"
-    ember-wormhole "^0.5.2"
 
 ember-truth-helpers@1.3.0:
   version "1.3.0"
@@ -5536,11 +5510,11 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.5:
+iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.21"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
@@ -7265,6 +7239,23 @@ nypr-ads@~0.0.0:
     ember-cli-babel "^5.1.7"
     ember-cli-htmlbars "^1.1.1"
 
+nypr-audio-services@>=0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/nypr-audio-services/-/nypr-audio-services-0.3.3.tgz#67b8d55233240814b60678721f4adde7728d503e"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+    ember-cli-sass "^7.0.0"
+    ember-diff-attrs "^0.2.1"
+    ember-fetch "^3.3.0"
+    ember-get-config "^0.2.2"
+    ember-hifi "^1.11.1"
+    ember-simple-auth "^1.3.0"
+    liquid-fire "^0.29.1"
+    nypr-metrics ">=0.3.0"
+    nypr-ui ">=0.2.0"
+
 nypr-audio-services@~0.0.0:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/nypr-audio-services/-/nypr-audio-services-0.0.9.tgz#b7dbce9fcb82dd942ec2b262154da7272362f7cd"
@@ -7282,23 +7273,6 @@ nypr-audio-services@~0.0.0:
     nypr-metrics "~0.0.0"
     nypr-ui "~0.1.0"
 
-nypr-audio-services@~0.2.0:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/nypr-audio-services/-/nypr-audio-services-0.2.6.tgz#841be1abd2a59ba9d849654019d32da64264f65b"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-    ember-cli-htmlbars "^2.0.1"
-    ember-cli-htmlbars-inline-precompile "^1.0.0"
-    ember-cli-sass "^7.0.0"
-    ember-diff-attrs "^0.1.2"
-    ember-fetch "^3.3.0"
-    ember-get-config "^0.2.2"
-    ember-hifi "^1.11.1"
-    ember-simple-auth "^1.3.0"
-    liquid-fire "^0.29.1"
-    nypr-metrics "~0.2.5"
-    nypr-ui "~0.1.0"
-
 nypr-auth@~0.0.0:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/nypr-auth/-/nypr-auth-0.0.2.tgz#002df7e89960c24ac7b0861b2f774b06780ee7fc"
@@ -7306,6 +7280,14 @@ nypr-auth@~0.0.0:
     ember-cli-babel "^6.3.0"
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.4.0"
+
+nypr-django-for-ember@>=0.1.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nypr-django-for-ember/-/nypr-django-for-ember-0.2.0.tgz#b91a133a666be24193ca7ae58f0fac05c075c531"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-wormhole "^0.5.2"
 
 nypr-django-for-ember@~0.0.0:
   version "0.0.4"
@@ -7315,7 +7297,7 @@ nypr-django-for-ember@~0.0.0:
     ember-cli-htmlbars "^2.0.1"
     ember-wormhole "^0.5.2"
 
-nypr-metrics@<0.1.0, nypr-metrics@>=0.3.0, nypr-metrics@~0.0.0, nypr-metrics@~0.2.5:
+nypr-metrics@<0.1.0, nypr-metrics@>=0.3.0, nypr-metrics@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/nypr-metrics/-/nypr-metrics-0.0.1.tgz#5954087401a04f3cf19c878191d6b638cbbd1b20"
   dependencies:
@@ -7337,9 +7319,9 @@ nypr-player@~0.0.0:
     ember-moment "^7.4.1"
     nypr-ui "~0.1.0"
 
-nypr-publisher-lib@^0.2.15:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.2.15.tgz#1d3bd9b1ab5c0221c5b7a50d4a7ac3c5f5efc120"
+nypr-publisher-lib@>=0.3.0:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.3.7.tgz#eafd2a920da3f5e6625ec13927558275b6f9651c"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -7350,13 +7332,12 @@ nypr-publisher-lib@^0.2.15:
     ember-click-outside "^0.1.12"
     ember-font-awesome "^4.0.0-rc.1"
     ember-get-config "^0.2.2"
-    ember-truncate "^1.0.0"
     liquid-fire "~0.29.1"
-    nypr-audio-services "~0.2.0"
-    nypr-django-for-ember "~0.0.0"
-    nypr-ui "~0.1.5"
+    nypr-audio-services ">=0.3.0"
+    nypr-django-for-ember ">=0.1.0"
+    nypr-ui ">=0.2.4"
 
-nypr-ui@>=0.2.0:
+nypr-ui@>=0.2.0, nypr-ui@>=0.2.4:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.2.6.tgz#282b712df5fbbc58c643fa93130ba7a79c8cc139"
   dependencies:
@@ -7373,7 +7354,7 @@ nypr-ui@>=0.2.0:
     ivy-tabs "^3.3.0"
     waypoints "^4.0.1"
 
-nypr-ui@~0.1.0, nypr-ui@~0.1.5, nypr-ui@~0.1.7:
+nypr-ui@~0.1.0, nypr-ui@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.1.8.tgz#2b71a6f5564aa1335efb55811047df9317c2f480"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,15 +3,17 @@
 
 
 "@ember-decorators/argument@ember-decorators/argument":
-  version "0.8.12"
-  resolved "https://codeload.github.com/ember-decorators/argument/tar.gz/80d75a27dab4070fd9e115b5be7f63293a1d9831"
+  version "0.8.13"
+  resolved "https://codeload.github.com/ember-decorators/argument/tar.gz/2b1dc14362214e906591f6ed0cf66db2676aa4d0"
   dependencies:
     babel-plugin-filter-imports "^1.1.1"
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.3.0"
     ember-cli-version-checker "^2.0.0"
-    ember-compatibility-helpers "^0.1.1"
+    ember-compatibility-helpers "^1.0.0-beta.2"
     ember-get-config "^0.2.3"
+    ember-source-channel-url "^1.0.1"
+    ember-try "^0.2.23"
 
 "@ember-decorators/babel-transforms@^0.1.1":
   version "0.1.1"
@@ -75,6 +77,10 @@
   dependencies:
     "@glimmer/util" "^0.27.0"
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
@@ -109,9 +115,13 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.2.1, acorn@^5.5.0:
+acorn@^5.2.1:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.0.tgz#1abb587fbf051f94e3de20e6b26ef910b1828298"
 
 after@0.8.1:
   version "0.8.1"
@@ -694,8 +704,8 @@ babel-plugin-filter-imports@^1.1.1:
     lodash "^4.17.4"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz#cd365e278af409bfa6be7704c4354beee742446b"
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.4.tgz#54b48168432bbc03f1f26f2e9090cb222bc78c75"
 
 babel-plugin-inline-environment-variables@^1.0.1:
   version "1.0.1"
@@ -1551,6 +1561,13 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
+"broccoli-merge-trees@^2.0.0 || ^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz#a21f255f8bfe5a21c2f0fbf2417addd9d24c9436"
@@ -1814,6 +1831,18 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 calculate-cache-key-for-tree@^1.0.0, calculate-cache-key-for-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
@@ -1864,8 +1893,8 @@ caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000813.tgz#e0a1c603f8880ad787b2a35652b2733f32a5e29a"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000813"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz#7b25e27fdfb8d133f3c932b01f77452140fcc6c9"
+  version "1.0.30000827"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz#2dad2354e4810c3c9bb1cfc57f655c270c25fa52"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -1915,7 +1944,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
@@ -2001,6 +2030,10 @@ clean-css@^3.4.5:
     commander "2.8.x"
     source-map "0.4.x"
 
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
+
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -2052,13 +2085,19 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  dependencies:
+    mimic-response "^1.0.0"
+
 clone@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f"
 
 clone@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
 co@^4.6.0:
   version "4.6.0"
@@ -2117,9 +2156,13 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+commander@^2.5.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@^2.6.0, commander@^2.9.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 common-tags@^1.4.0:
   version "1.7.2"
@@ -2263,8 +2306,8 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
 core-object@2.0.6:
   version "2.0.6"
@@ -2424,6 +2467,12 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
 
 deep-equal@~0.1.2:
   version "0.1.2"
@@ -2620,6 +2669,10 @@ double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2634,9 +2687,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
-  version "1.3.36"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz#0eabf71a9ebea9013fb1cc35a390e068624f27e8"
+electron-to-chromium@^1.2.7:
+  version "1.3.35"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.35.tgz#693c17cfb93841d38cb59b8df019d17e356985f0"
+
+electron-to-chromium@^1.3.30:
+  version "1.3.42"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
 
 ember-ajax@^3.0.0:
   version "3.0.0"
@@ -2674,6 +2731,16 @@ ember-body-class@0.4.0:
   resolved "https://registry.yarnpkg.com/ember-body-class/-/ember-body-class-0.4.0.tgz#0994243f9d4978ccaec287cfdbedcb78b46e28c5"
   dependencies:
     ember-cli-babel "^5.0.0"
+
+ember-burger-menu@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-burger-menu/-/ember-burger-menu-3.1.0.tgz#1f7325aca11393d5a7f682e5634cfd94dc4f09b6"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^1.1.1"
+    ember-lifeline "^2.0.0"
+    ember-require-module "^0.2.0"
+    ember-wormhole "0.5.3"
 
 ember-changeset-validations@^1.2.8:
   version "1.2.11"
@@ -2713,9 +2780,19 @@ ember-cli-autoprefixer@^0.6.0:
     broccoli-autoprefixer "^4.1.0"
     lodash "^4.0.0"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
+  dependencies:
+    broccoli-babel-transpiler "^5.6.2"
+    broccoli-funnel "^1.0.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^1.0.2"
+    resolve "^1.1.2"
+
+ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz#0356b03cc3fdff5d0f2ecaa46a0e1cfaebffd876"
   dependencies:
     broccoli-babel-transpiler "^5.6.2"
     broccoli-funnel "^1.0.0"
@@ -3121,7 +3198,7 @@ ember-cli-sass@7.0.0:
     broccoli-sass-source-maps "^2.0.0"
     ember-cli-version-checker "^1.0.2"
 
-ember-cli-sass@^7.0.0:
+ember-cli-sass@^7.0.0, ember-cli-sass@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/ember-cli-sass/-/ember-cli-sass-7.1.7.tgz#66899134788ec8d2406a45f5346d4db47a2aa012"
   dependencies:
@@ -3303,9 +3380,9 @@ ember-click-outside@^0.1.12:
     ember-cli-babel "^6.3.0"
     ember-cli-htmlbars "^2.0.1"
 
-ember-compatibility-helpers@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.3.tgz#039a57e9f1a401efda0023c1e3650bd01cfd7087"
+ember-compatibility-helpers@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"
@@ -3318,9 +3395,17 @@ ember-composable-helpers@2.0.3:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
 
-ember-concurrency@^0.8.1, ember-concurrency@^0.8.12, ember-concurrency@^0.8.2:
+ember-concurrency@^0.8.1, ember-concurrency@^0.8.2:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.16.tgz#979fab6fb7e3105e695defb39e7a4b641237944d"
+  dependencies:
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.8.2"
+    ember-maybe-import-regenerator "^0.1.5"
+
+ember-concurrency@^0.8.12:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.17.tgz#be47a90342f1960f4f57284c2fe5f7ce2396142a"
   dependencies:
     babel-core "^6.24.1"
     ember-cli-babel "^6.8.2"
@@ -3336,6 +3421,13 @@ ember-cookies@0.0.13:
 "ember-cookies@^0.1.0 || ^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.2.0.tgz#81195a31a36447240fb97af47d01ad582f747d47"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
+
+ember-cookies@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.3.0.tgz#f9a23c957bd0e561e6a056e044d95ce2416b64d8"
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-getowner-polyfill "^1.1.0 || ^2.0.0"
@@ -3423,6 +3515,13 @@ ember-diff-attrs@^0.1.2:
     ember-cli-babel "^5.1.7"
     ember-weakmap "2.0.0"
 
+ember-diff-attrs@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-diff-attrs/-/ember-diff-attrs-0.2.1.tgz#ad9592ab8ba63d796bb9b1633801fe27ca43fc74"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-weakmap "^3.0.0"
+
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -3441,7 +3540,18 @@ ember-feature-flags@3.0.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-"ember-fetch@^2.1.0 || ^3.0.0", ember-fetch@^3.2.9, ember-fetch@^3.3.0:
+"ember-fetch@^2.1.0 || ^3.0.0", ember-fetch@^3.3.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-3.4.5.tgz#2967df9cbdbe0993402588216332580be3950b92"
+  dependencies:
+    broccoli-funnel "^1.2.0"
+    broccoli-stew "^1.4.2"
+    broccoli-templater "^1.0.0"
+    ember-cli-babel "^6.8.2"
+    node-fetch "^2.0.0-alpha.9"
+    whatwg-fetch "^2.0.3"
+
+ember-fetch@^3.2.9:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-3.4.4.tgz#926ffa1c4120324b298c44e9558b458e586eb504"
   dependencies:
@@ -3521,6 +3631,14 @@ ember-holygrail-layout@^0.1.4:
     ember-cli-babel "^5.1.6"
     ember-cli-htmlbars "^1.0.3"
 
+ember-holygrail-layout@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-holygrail-layout/-/ember-holygrail-layout-0.3.0.tgz#6244f5696495fcb8530bacba633d27cf10cbd6e5"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+
 ember-hotjar@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/ember-hotjar/-/ember-hotjar-0.0.2.tgz#fc93dfccc07f4787438c6c8fea39dee97b414446"
@@ -3552,6 +3670,12 @@ ember-lifeline@^1.3.0:
   resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-1.3.0.tgz#33baf11287ea425103cd6c3299b9d9d15d1e4c54"
   dependencies:
     ember-cli-babel "^5.1.7"
+
+ember-lifeline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-2.0.0.tgz#ab2dadd3eed585605d1c4137c64aacec4d241c8e"
+  dependencies:
+    ember-cli-babel "^6.8.2"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"
@@ -3711,7 +3835,11 @@ ember-responsive@^2.0.4:
     ember-cli-babel "^6.4.1"
     ember-getowner-polyfill "^1.1.1"
 
-ember-rfc176-data@^0.3.0, ember-rfc176-data@^0.3.1:
+ember-rfc176-data@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.2.tgz#bde5538939529b263c142b53a47402f8127f8dce"
+
+ember-rfc176-data@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz#6a5a4b8b82ec3af34f3010965fa96b936ca94519"
 
@@ -3749,7 +3877,22 @@ ember-scroll-to@0.6.4:
     ember-cli-babel "^5.1.6"
     ember-cli-htmlbars "^1.0.3"
 
-ember-simple-auth@^1.3.0, ember-simple-auth@^1.4.0:
+ember-simple-auth@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.6.0.tgz#68a80cdc4f2928a87af0f68aefae5abfd70f2e36"
+  dependencies:
+    base-64 "^0.1.0"
+    broccoli-file-creator "^1.1.1"
+    broccoli-funnel "^1.2.0 || ^2.0.0"
+    broccoli-merge-trees "^2.0.0 || ^3.0.0"
+    ember-cli-babel "^6.8.2"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cookies "^0.3.0"
+    ember-fetch "^2.1.0 || ^3.0.0"
+    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
+    silent-error "^1.0.0"
+
+ember-simple-auth@^1.4.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.5.1.tgz#aa28fda5af5148b4a0ee823302e600598ccff4d8"
   dependencies:
@@ -3801,6 +3944,12 @@ ember-sortable@1.9.4:
     ember-cli-htmlbars "^1.0.10"
     ember-invoke-action "^1.4.0"
     ember-new-computed "^1.0.2"
+
+ember-source-channel-url@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-source-channel-url/-/ember-source-channel-url-1.0.1.tgz#93517ccbd97a26220184b7986a5325317065308b"
+  dependencies:
+    got "^8.0.1"
 
 ember-source@~2.16.0:
   version "2.16.4"
@@ -3860,7 +4009,7 @@ ember-try-config@^2.2.0:
     rsvp "^3.2.1"
     semver "^5.1.0"
 
-ember-try@^0.2.15:
+ember-try@^0.2.15, ember-try@^0.2.23:
   version "0.2.23"
   resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.23.tgz#39b57141b4907541d0ac8b503d211e6946b08718"
   dependencies:
@@ -3903,6 +4052,13 @@ ember-weakmap@^3.0.0:
     browserslist "^2.2.2"
     debug "^3.1.0"
     ember-cli-babel "^6.3.0"
+
+ember-wormhole@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.3.tgz#441fdd7729a3b5eed3b0103db84f0ab880ac7f87"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-cli-htmlbars "^2.0.1"
 
 ember-wormhole@^0.5.1, ember-wormhole@^0.5.2:
   version "0.5.4"
@@ -4619,6 +4775,13 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -4700,6 +4863,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -4776,7 +4949,7 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stream@^3.0.0:
+get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
@@ -4952,6 +5125,28 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.4"
     minimatch "~3.0.2"
+
+got@^8.0.1:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.0.tgz#6ba26e75f8a6cc4c6b3eb1fe7ce4fec7abac8533"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -5130,6 +5325,16 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbol-support-x@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-to-string-tag-x@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
+  dependencies:
+    has-symbol-support-x "^1.4.1"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -5199,14 +5404,14 @@ heimdalljs-graph@^0.3.1:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz#0bd75797beeaa20b0ed59017aed3b2d95312acee"
 
-heimdalljs-logger@^0.1.7:
+heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz#d76ada4e45b7bb6f786fc9c010a68eb2e2faf176"
   dependencies:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -5275,6 +5480,10 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -5327,9 +5536,15 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
+iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@^0.4.5:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -5434,9 +5649,16 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
+
 invariant@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -5612,6 +5834,10 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-odd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
@@ -5633,6 +5859,10 @@ is-path-inside@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -5659,6 +5889,10 @@ is-property@^1.0.0:
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-retry-allowed@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -5724,12 +5958,26 @@ istextorbinary@2.1.0:
     editions "^1.1.1"
     textextensions "1 || 2"
 
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
+  dependencies:
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
+
 ivy-tabs@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ivy-tabs/-/ivy-tabs-3.1.0.tgz#07eae83bf46c974bf7de2f4d9404a7abaebe39fe"
   dependencies:
     ember-cli-babel "^5.1.7"
     ember-cli-htmlbars "^1.0.10"
+
+ivy-tabs@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ivy-tabs/-/ivy-tabs-3.3.0.tgz#e29efcba1aaed855e97f5fa4789b1ac7387a32ac"
+  dependencies:
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars "^2.0.3"
 
 jmespath@0.15.0:
   version "0.15.0"
@@ -5796,6 +6044,10 @@ jsesc@~0.5.0:
 jsmin@1.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
+
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -5878,6 +6130,12 @@ jxLoader@*:
     moo-server "1.3.x"
     promised-io "*"
     walker "1.x"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -6437,6 +6695,14 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lowercase-keys@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lowercase-keys@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+
 lru-cache@2, lru-cache@^2.6.5:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
@@ -6564,6 +6830,13 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -6629,6 +6902,10 @@ mime@^1.2.11, mime@^1.3.4:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 minimatch@0.3:
   version "0.3.0"
@@ -6802,8 +7079,8 @@ node-fetch@^1.3.3:
     is-stream "^1.0.1"
 
 node-fetch@^2.0.0-alpha.9:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.1.tgz#369ca70b82f50c86496104a6c776d274f4e4a2d4"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-gyp@^3.3.1:
   version "3.6.2"
@@ -6918,6 +7195,14 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 npm-git-info@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"
@@ -7030,7 +7315,7 @@ nypr-django-for-ember@~0.0.0:
     ember-cli-htmlbars "^2.0.1"
     ember-wormhole "^0.5.2"
 
-nypr-metrics@<0.1.0, nypr-metrics@~0.0.0, nypr-metrics@~0.2.5:
+nypr-metrics@<0.1.0, nypr-metrics@>=0.3.0, nypr-metrics@~0.0.0, nypr-metrics@~0.2.5:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/nypr-metrics/-/nypr-metrics-0.0.1.tgz#5954087401a04f3cf19c878191d6b638cbbd1b20"
   dependencies:
@@ -7070,6 +7355,23 @@ nypr-publisher-lib@^0.2.15:
     nypr-audio-services "~0.2.0"
     nypr-django-for-ember "~0.0.0"
     nypr-ui "~0.1.5"
+
+nypr-ui@>=0.2.0:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.2.6.tgz#282b712df5fbbc58c643fa93130ba7a79c8cc139"
+  dependencies:
+    ember-basic-dropdown "0.33.1"
+    ember-burger-menu "^3.1.0"
+    ember-cli-babel "^6.8.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+    ember-cli-sass "^7.1.7"
+    ember-click-outside "0.1.11"
+    ember-composable-helpers "2.0.3"
+    ember-holygrail-layout "^0.3.0"
+    ember-power-select "^1.9.2"
+    ivy-tabs "^3.3.0"
+    waypoints "^4.0.1"
 
 nypr-ui@~0.1.0, nypr-ui@~0.1.5, nypr-ui@~0.1.7:
   version "0.1.8"
@@ -7224,9 +7526,17 @@ output-file-sync@^1.1.0:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+p-cancelable@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 p-limit@^1.1.0:
   version "1.2.0"
@@ -7239,6 +7549,12 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -7420,16 +7736,20 @@ postcss@^5.0.4, postcss@^5.2.16:
     supports-color "^3.2.3"
 
 postcss@^6.0.14:
-  version "6.0.19"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
   dependencies:
-    chalk "^2.3.1"
+    chalk "^2.3.2"
     source-map "^0.6.1"
-    supports-color "^5.2.0"
+    supports-color "^5.3.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -7520,6 +7840,14 @@ qs@~6.3.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+query-string@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring@0.2.0:
   version "0.2.0"
@@ -7616,6 +7944,18 @@ readable-stream@2, readable-stream@^2, readable-stream@^2.0.1, readable-stream@^
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.0:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readable-stream@~1.0.0, readable-stream@~1.0.2:
@@ -7932,15 +8272,27 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@1.5.0, resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
+resolve@1.5.0, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.1.2, resolve@^1.1.6, resolve@^1.3.3, resolve@^1.4.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.0.tgz#2bdf5374811207285df0df652b78f118ab8f3c5e"
   dependencies:
     path-parse "^1.0.5"
 
 resolve@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  dependencies:
+    lowercase-keys "^1.0.0"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -7966,7 +8318,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -8039,6 +8391,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 samsam@1.3.0, samsam@1.x, samsam@^1.1.3:
   version "1.3.0"
@@ -8350,6 +8706,12 @@ socks@^1.1.10:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 sort-object-keys@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.2.tgz#d3a6c48dc2ac97e6bc94367696e03f6d09d37952"
@@ -8538,6 +8900,10 @@ streamsearch@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
 
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
 string-template@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
@@ -8564,6 +8930,12 @@ string_decoder@0.10, string_decoder@~0.10.x:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -8645,7 +9017,7 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.2.0, supports-color@^5.3.0:
+supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
@@ -8801,6 +9173,10 @@ through@^2.3.6, through@^2.3.8, through@~2.3.8:
 thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
+
+timed-out@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timespan@2.x:
   version "2.3.0"
@@ -9066,6 +9442,16 @@ url-join@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-0.0.1.tgz#1db48ad422d3402469a87f7d97bdebfe4fb1e3c8"
 
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  dependencies:
+    prepend-http "^2.0.0"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
+
 url-toolkit@^2.0.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.4.tgz#e0dac60e5fdd50b8ac984307699e8b72439b3fd3"
@@ -9189,8 +9575,8 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 whatwg-fetch@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,13 +1561,6 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-"broccoli-merge-trees@^2.0.0 || ^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
-  dependencies:
-    broccoli-plugin "^1.3.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz#a21f255f8bfe5a21c2f0fbf2417addd9d24c9436"
@@ -2029,10 +2022,6 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
-
-clean-up-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -3429,13 +3418,6 @@ ember-cookies@0.0.13:
     ember-cli-babel "^6.8.2"
     ember-getowner-polyfill "^1.1.0 || ^2.0.0"
 
-ember-cookies@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.3.0.tgz#f9a23c957bd0e561e6a056e044d95ce2416b64d8"
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
-
 ember-data@2.14.10:
   version "2.14.10"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.14.10.tgz#acf66ffffb062a7fc999f9d989d0e0d2e3858cd3"
@@ -3518,13 +3500,6 @@ ember-diff-attrs@^0.1.2:
   dependencies:
     ember-cli-babel "^5.1.7"
     ember-weakmap "2.0.0"
-
-ember-diff-attrs@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ember-diff-attrs/-/ember-diff-attrs-0.2.1.tgz#ad9592ab8ba63d796bb9b1633801fe27ca43fc74"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-    ember-weakmap "^3.0.0"
 
 ember-export-application-global@^2.0.0:
   version "2.0.0"
@@ -3875,22 +3850,7 @@ ember-scroll-to@0.6.4:
     ember-cli-babel "^5.1.6"
     ember-cli-htmlbars "^1.0.3"
 
-ember-simple-auth@^1.3.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.6.0.tgz#68a80cdc4f2928a87af0f68aefae5abfd70f2e36"
-  dependencies:
-    base-64 "^0.1.0"
-    broccoli-file-creator "^1.1.1"
-    broccoli-funnel "^1.2.0 || ^2.0.0"
-    broccoli-merge-trees "^2.0.0 || ^3.0.0"
-    ember-cli-babel "^6.8.2"
-    ember-cli-is-package-missing "^1.0.0"
-    ember-cookies "^0.3.0"
-    ember-fetch "^2.1.0 || ^3.0.0"
-    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
-    silent-error "^1.0.0"
-
-ember-simple-auth@^1.4.0:
+ember-simple-auth@^1.3.0, ember-simple-auth@^1.4.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.5.1.tgz#aa28fda5af5148b4a0ee823302e600598ccff4d8"
   dependencies:
@@ -4837,16 +4797,6 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
-fs-updater@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
-  dependencies:
-    can-symlink "^1.0.0"
-    clean-up-path "^1.0.0"
-    heimdalljs "^0.2.5"
-    heimdalljs-logger "^0.1.9"
-    rimraf "^2.6.2"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -5378,14 +5328,14 @@ heimdalljs-graph@^0.3.1:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz#0bd75797beeaa20b0ed59017aed3b2d95312acee"
 
-heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
+heimdalljs-logger@^0.1.7:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz#d76ada4e45b7bb6f786fc9c010a68eb2e2faf176"
   dependencies:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -6804,13 +6754,6 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-merge-trees@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
-  dependencies:
-    fs-updater "^1.0.4"
-    heimdalljs "^0.2.5"
-
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -7239,22 +7182,22 @@ nypr-ads@~0.0.0:
     ember-cli-babel "^5.1.7"
     ember-cli-htmlbars "^1.1.1"
 
-nypr-audio-services@>=0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/nypr-audio-services/-/nypr-audio-services-0.3.3.tgz#67b8d55233240814b60678721f4adde7728d503e"
+nypr-audio-services@0.2.7, nypr-audio-services@>=0.3.0:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/nypr-audio-services/-/nypr-audio-services-0.2.7.tgz#a15c6e5ae975431a48d413170efc84d8b4264b8e"
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
     ember-cli-sass "^7.0.0"
-    ember-diff-attrs "^0.2.1"
+    ember-diff-attrs "^0.1.2"
     ember-fetch "^3.3.0"
     ember-get-config "^0.2.2"
     ember-hifi "^1.11.1"
     ember-simple-auth "^1.3.0"
     liquid-fire "^0.29.1"
-    nypr-metrics ">=0.3.0"
-    nypr-ui ">=0.2.0"
+    nypr-metrics "~0.2.5"
+    nypr-ui "~0.1.0"
 
 nypr-audio-services@~0.0.0:
   version "0.0.9"
@@ -7297,7 +7240,7 @@ nypr-django-for-ember@~0.0.0:
     ember-cli-htmlbars "^2.0.1"
     ember-wormhole "^0.5.2"
 
-nypr-metrics@<0.1.0, nypr-metrics@>=0.3.0, nypr-metrics@~0.0.0:
+nypr-metrics@<0.1.0, nypr-metrics@~0.0.0, nypr-metrics@~0.2.5:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/nypr-metrics/-/nypr-metrics-0.0.1.tgz#5954087401a04f3cf19c878191d6b638cbbd1b20"
   dependencies:
@@ -7337,7 +7280,7 @@ nypr-publisher-lib@>=0.3.0:
     nypr-django-for-ember ">=0.1.0"
     nypr-ui ">=0.2.4"
 
-nypr-ui@>=0.2.0, nypr-ui@>=0.2.4:
+nypr-ui@>=0.2.4:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.2.6.tgz#282b712df5fbbc58c643fa93130ba7a79c8cc139"
   dependencies:
@@ -8299,7 +8242,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
For compatibility with publisher#369, this PR updates the web client to do a direct store request for a `channel`, aka `listing-page` aka `CrossChannel` object from publisher.

This has two advantages:
1. Move away from depending on the `django-page` component for rendering, slightly improving performance
2. No longer requiring embedded raw JSON text on the initial request for loading up data. This technique proved fragile and error-prone. Show pages should stop dying due to embedded script tags in text fields now.

[ticket](https://jira.wnyc.org/browse/RT-658)