### PR TITLE
make sure urls created by and used within the ember app have trailing…

### DIFF
--- a/app/locations/trailing-history.js
+++ b/app/locations/trailing-history.js
@@ -1,0 +1,15 @@
+// adds a trailing slash to urls that need to be created and added to href elements
+// (ie this would be used by link-to)
+import HistoryLocation from '@ember/routing/history-location';
+
+export default HistoryLocation.extend({
+  formatURL() {
+    let url = this._super(...arguments);
+
+    if (url.includes('#')) {
+      return url.replace(/([^/])#(.*)/, '$1/#$2');
+    } else {
+      return url.replace(/\/?$/, '/');
+    }
+  }
+});

--- a/config/environment.js
+++ b/config/environment.js
@@ -14,7 +14,7 @@ module.exports = function(environment) {
     modulePrefix: 'wqxr-web-client',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'trailing-history',
     emberHifi: {
       connections: [{
         name: 'NativeAudio'


### PR DESCRIPTION
… slashes, to match the format enforced by publisher which expects a trailing slash on route urls.