### PR TITLE
Bscharenberg/mt 62

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,13 +1,6 @@
 // must come first as per CSS spec
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,300,700|Lato:400,400i,700,700i');
 
-// hide everything not ember so we can control the UI over the alien DOM
-body:not(.simplified_wrapper):not(.container_stripped) {
-   > :not(.ember-view):not(#qunit):not(#qunit-fixture):not(#ember-testing-container):not(#modal-overlays):not(#ember-basic-dropdown-wormhole) {
-    //display: none;
-  }
-}
-
 // contain fixed layouts
 #ember-testing {
   transform: translateZ(0);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -4,7 +4,7 @@
 // hide everything not ember so we can control the UI over the alien DOM
 body:not(.simplified_wrapper):not(.container_stripped) {
    > :not(.ember-view):not(#qunit):not(#qunit-fixture):not(#ember-testing-container):not(#modal-overlays):not(#ember-basic-dropdown-wormhole) {
-    display: none;
+    //display: none;
   }
 }
 


### PR DESCRIPTION
This PR is to remove an scss rule blocking the hotjar popup. The rule hid all divs without certain labels, and was meant to hide the html making up django pages delivered by the server on a cold boot from showing up until it gets processed by the ember app. However, another rule was added sometime later that does the exact same thing, but only until the app is initialized. So the more general rule can be deleted. 