### PR TITLE
Add isPayment field to order model

### DIFF
--- a/app/models/order.js
+++ b/app/models/order.js
@@ -15,6 +15,7 @@ export default Model.extend({
   creditCardLast4Digits: attr('string'),
   isActiveMember: attr('boolean'),
   isSustainer: attr('boolean'),
+  isPayment: attr('boolean'),
   updateLink: computed('fund', function() {
     let pledgeDomain = this.get('fund') === 'WQXR' ? 'wqxr' : 'wnyc';
     let fundSlug = this.get('fund').toLowerCase().replace(/[. ]/g, '');


### PR DESCRIPTION
- Add isPayment field to order model. This is currently an actively and correct field returned by nF and used in the member-center. Member Center is not reporting accurate gift/payment history because of the omission of this field.
- Further work to be done in repo: nypr-account-settings to correct member center display errors