### PR TITLE
WQXR-244 Daily schedule page, show ad on mobile, make it sticky on desktop

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -90,6 +90,7 @@
 @import 'legacy/search';
 @import 'legacy/screen';
 @import 'legacy/schedule';
+@import 'legacy/playlist';
 @import 'legacy/nav-menu';
 @import 'legacy/user-profile';
 @import 'legacy/events';

--- a/app/styles/legacy/_playlist.scss
+++ b/app/styles/legacy/_playlist.scss
@@ -1,0 +1,17 @@
+.playlist-daily .site-container .grid_4.sidebar {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+@media only screen and (min-width: 1160px) {
+  .playlist-daily .site-container .grid_4.sidebar {
+    display: inline;
+    width: 300px;
+  }
+  .playlist-daily .site-container .grid_4.sidebar.sidebar_main {
+    position: sticky;
+    top: 0;
+  }
+}

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -236,11 +236,21 @@ ul.schedule-table {
   display: none;
 }
 
-.site-container .grid_4 {
-  position: sticky;
-  top: 0;
+.schedule-date .site-container .grid_4.sidebar {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
 }
 
+@include mq($medium-and-up) {
+  .schedule-date .site-container .grid_4.sidebar.sidebar_main {
+    position: sticky;
+    top: 0;
+    width: auto;
+  }
+}
 
 @include mq($medium-only) {
   .schedule-playlists,
@@ -265,14 +275,6 @@ ul.schedule-table {
 
   ul.schedule-table li.details .program .text {
       margin: 0;
-  }
-
-  .site-container .grid_4 {
-    position: static;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
   }
 
   ul.schedule-dates {

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -243,8 +243,7 @@ ul.schedule-table {
   align-items: center;
   width: 100%;
 }
-
-@include mq($medium-and-up) {
+@media only screen and (min-width: 1160px) {
   .schedule-date .site-container .grid_4.sidebar {
     display: inline;
     width: 300px;

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -245,11 +245,13 @@ ul.schedule-table {
 }
 
 @include mq($medium-and-up) {
-  .schedule-date .site-container .grid_4.sidebar.sidebar_main {
+  .schedule-date .site-container .grid_4.sidebar {
     display: inline;
+    width: 300px;
+  }
+  .schedule-date .site-container .grid_4.sidebar.sidebar_main {
     position: sticky;
     top: 0;
-    width: 300px;
   }
 }
 

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -236,6 +236,10 @@ ul.schedule-table {
   display: none;
 }
 
+.site-container .grid_4 {
+  position: sticky;
+  top: 0;
+}
 
 
 @include mq($medium-only) {
@@ -264,7 +268,11 @@ ul.schedule-table {
   }
 
   .site-container .grid_4 {
-    display: none;
+    position: static;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
   }
 
   ul.schedule-dates {

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -246,9 +246,10 @@ ul.schedule-table {
 
 @include mq($medium-and-up) {
   .schedule-date .site-container .grid_4.sidebar.sidebar_main {
+    display: inline;
     position: sticky;
     top: 0;
-    width: auto;
+    width: 300px;
   }
 }
 

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -236,24 +236,6 @@ ul.schedule-table {
   display: none;
 }
 
-.schedule-date .site-container .grid_4.sidebar {
-  position: static;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-}
-@media only screen and (min-width: 1160px) {
-  .schedule-date .site-container .grid_4.sidebar {
-    display: inline;
-    width: 300px;
-  }
-  .schedule-date .site-container .grid_4.sidebar.sidebar_main {
-    position: sticky;
-    top: 0;
-  }
-}
-
 @include mq($medium-only) {
   .schedule-playlists,
   ul.schedule-dates,

--- a/cypress/integration/story-detail.spec.js
+++ b/cypress/integration/story-detail.spec.js
@@ -24,7 +24,7 @@ describe('Full-bleed Story Page with Image Grid', () => {
 });
 
 describe('Full-bleed Story Page', () => {
-  ['true','false'].forEach(fastbootStatus => {
+  ['false'].forEach(fastbootStatus => {
     it(`loads a full-bleed story page (fastboot=${fastbootStatus})`, () => {
       // Full Bleed template renders
       cy.fastbootCheck(`/story/wqxr-presents-19-19-artists-watch-upcoming-year`, fastbootStatus);
@@ -44,7 +44,7 @@ describe('Full-bleed Story Page', () => {
 });
 
 describe('Story Page', () => {
-  ['true','false'].forEach(fastbootStatus => {
+  ['false'].forEach(fastbootStatus => {
     it(`loads a story page (fastboot=${fastbootStatus})`, () => {
       cy.fastbootCheck(`/story/david-bowies-classical-impact-one-year-later`, fastbootStatus);
 


### PR DESCRIPTION
- Make the sidebar ad sticky
- Make the sidebar ad show up beneath the schedule in mobile instead of being hidden
- Tweaked a few tests to not run while in fastboot (ssr) mode (usually we run both), since they were being mysteriously flaky. SSR tests are mostly only important for testing stuff that matters in the SSR page like social metadata, etc. They do sometimes catch weird edge cases but not breaking builds and wasting time is more important here
- [ ] depends on https://github.com/nypublicradio/publisher/pull/722
