### PR TITLE
Revision to Main Navigation (SUP-8140)

### DIFF
--- a/app/components/site-chrome/template.hbs
+++ b/app/components/site-chrome/template.hbs
@@ -124,7 +124,7 @@ Using double link-to in order to get an active class on the li tag
           </li>
 
           <li class="list-item list-item--nav">
-            <a href="/shows/artist-propulsion-lab-show/" class="inherit gtm__click-tracking" data-action="Side Navigation">Artist Propulsion Lab</a>
+            <a href="/shows/live-broadcasts/" class="inherit gtm__click-tracking" data-action="Side Navigation">Live Broadcasts</a>
           </li>
 
           <li class="list-item list-item--nav">


### PR DESCRIPTION
Replaced the Artist Propulsion Lab Section link in the WQXR sidebar navigation with Live Broadcasts per SUP-8140 and DEVO-506 tickets.